### PR TITLE
[Perf] Add caching for Folders, Levels, and sprite IO operations

### DIFF
--- a/CustomLevels.csproj
+++ b/CustomLevels.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -37,9 +37,8 @@
     <Reference Include="UnityEngine.ImageConversionModule">
       <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Storyteller\BepInEx\interop\UnityEngine.ImageConversionModule.dll</HintPath>
     </Reference>
+    <Reference Include="GameAssembly">
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Storyteller\GameAssembly.dll</HintPath>
+    </Reference>
   </ItemGroup>
-
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="copy .\bin\Release\net6.0\CustomLevels.dll &quot;C:\Program Files (x86)\Steam\steamapps\common\Storyteller\BepInEx\plugins\CustomLevels.dll&quot;&#xD;&#xA;" />
-  </Target>
 </Project>

--- a/src/hooks/ResourceLoader.cs
+++ b/src/hooks/ResourceLoader.cs
@@ -85,15 +85,20 @@ internal class ResourceLoader_GetAnimation
         {
             return true;
         }
-        string fullFilePath;
+
+        string fullFilePath = null;
         byte[] data;
         DateTime time;
         try
         {
-            fullFilePath = ChapterUtils.GetFile(id + ".png") ?? ChapterUtils.GetFile(id + "_*.png");
+            fullFilePath = ChapterUtils.GetFile(id + ".png");
             if (fullFilePath == null)
             {
-                return true;
+              fullFilePath = ChapterUtils.GetFile(id + "_*.png");
+            }
+            if (fullFilePath == null)
+            {
+              return true;
             }
             time = File.GetLastWriteTimeUtc(fullFilePath);
             if (cache.TryGetValue(id, out var cached))


### PR DESCRIPTION
Found some places that could be optimized with a dictionary or two. The main reason was to fix some performance issues while playing on Steam Deck (I was regularly hitting 1-3fps while playing some custom levels). I have yet to test it out on my steam deck again. 🙂so I'll see what kind of improvement this change gives